### PR TITLE
fix: conditionally force Mesa GLX to avoid breaking NVIDIA GPU passthrough

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,20 @@ if ! nvidia-smi > /dev/null 2>&1; then
     echo "WARNING: The NVIDIA Driver was not detected. GPU functionality will not be available."
 fi
 
+# Conditionally force Mesa for software rendering.
+# Commit dd662d8 added __GLX_VENDOR_LIBRARY_NAME=mesa to fix window creation on
+# setups without NVIDIA GLX passthrough (e.g. CPU-only or WSL2 without graphics
+# bindings). However, forcing Mesa breaks native NVIDIA GLX passthrough because
+# Mesa tries to load the nvidia-drm DRI driver, which is not present in the
+# container, leading to Zink/Vulkan swapchain errors.
+# Only set it when NVIDIA GLX libraries are absent and the user hasn't
+# explicitly configured it.
+if [ -z "${__GLX_VENDOR_LIBRARY_NAME+x}" ]; then
+    if ! ldconfig -p 2>/dev/null | grep -q "libGLX_nvidia.so.0"; then
+        export __GLX_VENDOR_LIBRARY_NAME=mesa
+        echo "INFO: NVIDIA GLX libraries not found. Forcing Mesa for software rendering."
+    fi
+fi
+
 # keep container running
 exec "$@"

--- a/puffertank.dockerfile
+++ b/puffertank.dockerfile
@@ -66,8 +66,7 @@ RUN echo "export PS1=$''" >> ~/.bashrc \
  && echo "alias diff='diff --color --palette=':ad=36:de=31:ln=33''" >> ~/.bashrc \
  && echo "alias pip='uv pip'" >> ~/.bashrc \
  && echo ". /puffertank/venv/bin/activate" >> ~/.bashrc \
- && echo "cd /puffertank/pufferlib" >> ~/.bashrc \
- && echo "export __GLX_VENDOR_LIBRARY_NAME=mesa" >> ~/.bashrc
+ && echo "cd /puffertank/pufferlib" >> ~/.bashrc
 
 RUN apt-get clean
 CMD ["/bin/bash"]


### PR DESCRIPTION
Commit `dd662d8` (\"rendering fix\") added `export __GLX_VENDOR_LIBRARY_NAME=mesa` alongside the X11 auth fixes in `docker.sh`. I assume this commit was done, so on setups *without* NVIDIA GLX passthrough (CPU-only containers, or WSL2 where graphics bindings weren't fully working), it would fix the issue of GLFW/PufferLib not being able to create a window because libglvnd couldn't find a usable GLX vendor. Forcing Mesa makes those setups fall back to llvmpipe/Zink software rendering so `puffer eval` doesn't crash immediately.

**This breaks normal linux runs (at least on my machine)**
<img width="635" height="567" alt="2026-05-29-223025_635x567_scrot" src="https://github.com/user-attachments/assets/17a4e8f0-db5d-4f2a-8153-1bbaa64a2597" />
_Yes, I know my emoji fonts are broken. No I'm not going to fix it._

When you run with `--gpus all`, the NVIDIA Container Runtime injects the proprietary NVIDIA OpenGL libraries into the container. Hard-coding `__GLX_VENDOR_LIBRARY_NAME=mesa` tells libglvnd to ignore those libraries and use Mesa instead. Mesa then probes the PCI device (`10de:2783`), realizes the GPU is NVIDIA, and tries to load the `nvidia-drm` DRI driver — which isn't shipped inside the container. It falls back to Zink (Vulkan), which fails with `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`, and you get the `GLXBadCurrentWindow` crash.

**The conditional fix**
Instead of forcing Mesa unconditionally, I'm suggesting we now only set it when the NVIDIA GLX library (`libGLX_nvidia.so.0`) is actually absent from the container. If it's present, we leave libglvnd alone so it can select the native NVIDIA vendor. We also respect an explicit user override (if you manually set `__GLX_VENDOR_LIBRARY_NAME`, we won't touch it).

This was a whole load of yapping, just to essentially say: don't always force Mesa for GLX, as this can cause breakages in situations where the system doesn't _need/use_ Mesa.